### PR TITLE
fix: standardize CSS size modifiers to use numeric format

### DIFF
--- a/tanaka/docs/DESIGN-SYSTEM-GUIDE.md
+++ b/tanaka/docs/DESIGN-SYSTEM-GUIDE.md
@@ -202,7 +202,7 @@ This guide documents the standardized components and patterns in the Tanaka play
 ```html
 <div class="tnk-empty-state">
   <div class="tnk-empty-state__icon">
-    <i class="tnk-icon tnk-icon--xxxl ph ph-folder"></i>
+    <i class="tnk-icon tnk-icon--3xl ph ph-folder"></i>
   </div>
   <h3 class="tnk-empty-state__title">No Items</h3>
   <p class="tnk-empty-state__description">Create your first item to get started</p>
@@ -220,8 +220,8 @@ This guide documents the standardized components and patterns in the Tanaka play
 <i class="tnk-icon tnk-icon--md ph ph-warning"></i>
 <i class="tnk-icon tnk-icon--lg ph ph-star"></i>
 <i class="tnk-icon tnk-icon--xl ph ph-folder"></i>
-<i class="tnk-icon tnk-icon--xxl ph ph-check"></i>
-<i class="tnk-icon tnk-icon--xxxl ph ph-trophy"></i>
+<i class="tnk-icon tnk-icon--2xl ph ph-check"></i>
+<i class="tnk-icon tnk-icon--3xl ph ph-trophy"></i>
 <i class="tnk-icon tnk-icon--spinning ph ph-arrow-clockwise"></i>
 ```
 

--- a/tanaka/extension/.stylelintrc.json
+++ b/tanaka/extension/.stylelintrc.json
@@ -6,7 +6,7 @@
   ],
   "rules": {
     "selector-class-pattern": [
-      "^tnk-[a-z]+(-[a-z]+)*(__(([a-z]+(-[a-z]+)*)?))*(--[a-z]+(-[a-z]+)*)?$",
+      "^tnk-[a-z]+(-[a-z]+)*(__(([a-z]+(-[a-z]+)*)?))*(--[a-z0-9]+(-[a-z0-9]+)*)?$",
       {
         "message": "Class names must follow BEM pattern: tnk-block__element--modifier"
       }

--- a/tanaka/extension/src/playground/styles/core.css
+++ b/tanaka/extension/src/playground/styles/core.css
@@ -981,11 +981,11 @@ h3 {
   font-size: var(--tnk-icon-sz-xl);
 }
 
-.tnk-icon--xxl {
+.tnk-icon--2xl {
   font-size: var(--tnk-icon-sz-2xl);
 }
 
-.tnk-icon--xxxl {
+.tnk-icon--3xl {
   font-size: var(--tnk-icon-sz-3xl);
 }
 


### PR DESCRIPTION
## Summary

Standardized CSS size modifiers from alphabetic (`xxl`/`xxxl`) to numeric format (`2xl`/`3xl`) for better clarity and consistency with modern CSS conventions.

## Changes

- **extension/src/playground/styles/core.css** - Updated icon size modifier classes
- **docs/DESIGN-SYSTEM-GUIDE.md** - Updated documentation to reflect new naming
- **extension/.stylelintrc.json** - Updated BEM pattern to allow alphanumeric modifiers

## Rationale

1. **Industry standard** - Major CSS frameworks use numeric modifiers:
   - Tailwind CSS: `text-2xl`, `text-3xl`, `max-w-2xl`
   - Bootstrap: `col-12`, `offset-3`
   
2. **Better semantics** - `2xl` and `3xl` clearly indicate size progression vs `xxl`/`xxxl`

3. **BEM compliant** - Numbers in modifiers are acceptable per BEM methodology

4. **Consistency** - Our custom CSS properties already support numbers: `^tnk-[a-z0-9]+`

## Testing

- [x] All CSS linting passes
- [x] Visual inspection confirms no style changes
- [x] Design system documentation updated