### PR TITLE
refactor: migrate to semantic design tokens across playground-react

### DIFF
--- a/tanaka/extension/src/playground-react/app/app.scss
+++ b/tanaka/extension/src/playground-react/app/app.scss
@@ -8,7 +8,7 @@
 }
 
 .tnk-extension-pages-section__title {
-  font-size: var(--tnk-text-3xl);
+  font-size: var(--tnk-title-font-size);
   font-weight: var(--tnk-font-weight-semibold);
   color: var(--tnk-text-primary);
   /* margin-bottom: var(--tnk-space-sm); */

--- a/tanaka/extension/src/playground-react/components/Card/card.scss
+++ b/tanaka/extension/src/playground-react/components/Card/card.scss
@@ -12,12 +12,12 @@
 
   &:hover {
     border-color: var(--tnk-primary);
-    transform: translateY(-4px);
+    transform: translateY(var(--tnk-translate-hover-y));
     box-shadow: var(--tnk-shadow-lg);
   }
 
   &:active {
-    transform: translateY(0);
+    transform: translateY(var(--tnk-space-none));
   }
 }
 

--- a/tanaka/extension/src/playground-react/components/Icon/Icon.tsx
+++ b/tanaka/extension/src/playground-react/components/Icon/Icon.tsx
@@ -20,7 +20,7 @@ type IconPropsBase = {
 };
 
 const defaultProps = {
-  size: "medium",
+  size: "md",
   weight: "regular",
   spinning: false,
   className: "",

--- a/tanaka/extension/src/playground-react/components/Icon/icon.scss
+++ b/tanaka/extension/src/playground-react/components/Icon/icon.scss
@@ -7,43 +7,43 @@
   transition: all var(--tnk-transition-fast);
 
   &--xs {
-    width: var(--tnk-icon-sz-xs);
-    height: var(--tnk-icon-sz-xs);
+    width: var(--tnk-icon-size-xs);
+    height: var(--tnk-icon-size-xs);
   }
 
   &--sm {
-    width: var(--tnk-icon-sz-sm);
-    height: var(--tnk-icon-sz-sm);
+    width: var(--tnk-icon-size-sm);
+    height: var(--tnk-icon-size-sm);
   }
 
   &--md {
-    width: var(--tnk-icon-sz-md);
-    height: var(--tnk-icon-sz-md);
+    width: var(--tnk-icon-size-md);
+    height: var(--tnk-icon-size-md);
   }
 
   &--lg {
-    width: var(--tnk-icon-sz-lg);
-    height: var(--tnk-icon-sz-lg);
+    width: var(--tnk-icon-size-lg);
+    height: var(--tnk-icon-size-lg);
   }
 
   &--xl {
-    width: var(--tnk-icon-sz-xl);
-    height: var(--tnk-icon-sz-xl);
+    width: var(--tnk-icon-size-xl);
+    height: var(--tnk-icon-size-xl);
   }
 
   &--2xl {
-    width: var(--tnk-icon-sz-2xl);
-    height: var(--tnk-icon-sz-2xl);
+    width: var(--tnk-icon-size-2xl);
+    height: var(--tnk-icon-size-2xl);
   }
 
   &--3xl {
-    width: var(--tnk-icon-sz-3xl);
-    height: var(--tnk-icon-sz-3xl);
+    width: var(--tnk-icon-size-3xl);
+    height: var(--tnk-icon-size-3xl);
   }
 
   &--4xl {
-    width: var(--tnk-icon-sz-4xl);
-    height: var(--tnk-icon-sz-4xl);
+    width: var(--tnk-icon-size-4xl);
+    height: var(--tnk-icon-size-4xl);
   }
 
   &--spinning {

--- a/tanaka/extension/src/playground-react/components/app-logo/app-logo.scss
+++ b/tanaka/extension/src/playground-react/components/app-logo/app-logo.scss
@@ -13,8 +13,8 @@
   position: relative;
 
   &--sm {
-    width: var(--tnk-logo-size);
-    height: var(--tnk-logo-size);
+    width: var(--tnk-logo-size-sm);
+    height: var(--tnk-logo-size-sm);
     font-size: var(--tnk-text-2xl);
   }
 

--- a/tanaka/extension/src/playground-react/components/page-shell/page-shell.scss
+++ b/tanaka/extension/src/playground-react/components/page-shell/page-shell.scss
@@ -5,7 +5,7 @@
 
 .tnk-page-shell__header {
   background-color: var(--tnk-bg-secondary);
-  border-bottom: 0px;
+  border-bottom: var(--tnk-space-none);
   --app-shell-header-height: var(--tnk-space-7xl);
 }
 
@@ -26,6 +26,5 @@
 }
 
 .tnk-page-shell__main {
-  /*background-color: var(--tnk-bg-primary);*/
   margin-top: var(--tnk-space-7xl);
 }

--- a/tanaka/extension/src/playground-react/styles/_mantine_vars.scss
+++ b/tanaka/extension/src/playground-react/styles/_mantine_vars.scss
@@ -144,7 +144,7 @@
   /* Typography */
   --mantine-font-family: var(--tnk-font-family);
   --mantine-font-family-monospace: var(--tnk-font-mono);
-  --mantine-font-family-headings: var(--tnk-font-family);
+  --mantine-font-family-headings: var(--tnk-font-family-headings);
   --mantine-font-weight: var(--tnk-font-weight-normal);
   --mantine-font-weight-bold: var(--tnk-font-weight-bold);
   --mantine-font-size-xs: var(--tnk-text-xs);
@@ -152,31 +152,31 @@
   --mantine-font-size-md: var(--tnk-text-base);
   --mantine-font-size-lg: var(--tnk-text-lg);
   --mantine-font-size-xl: var(--tnk-text-xl);
-  --mantine-h1-font-size: var(--tnk-text-4xl);
-  --mantine-h2-font-size: var(--tnk-text-3xl);
-  --mantine-h3-font-size: var(--tnk-text-2xl);
-  --mantine-h4-font-size: var(--tnk-text-xl);
-  --mantine-h5-font-size: var(--tnk-text-lg);
-  --mantine-h6-font-size: var(--tnk-text-base);
-  --mantine-h1-font-weight: var(--tnk-font-weight-bold);
-  --mantine-h2-font-weight: var(--tnk-font-weight-bold);
-  --mantine-h3-font-weight: var(--tnk-font-weight-bold);
-  --mantine-h4-font-weight: var(--tnk-font-weight-semibold);
-  --mantine-h5-font-weight: var(--tnk-font-weight-semibold);
-  --mantine-h6-font-weight: var(--tnk-font-weight-medium);
+  --mantine-h1-font-size: var(--tnk-h1-font-size);
+  --mantine-h2-font-size: var(--tnk-h2-font-size);
+  --mantine-h3-font-size: var(--tnk-h3-font-size);
+  --mantine-h4-font-size: var(--tnk-h4-font-size);
+  --mantine-h5-font-size: var(--tnk-h5-font-size);
+  --mantine-h6-font-size: var(--tnk-h6-font-size);
+  --mantine-h1-font-weight: var(--tnk-h1-font-weight);
+  --mantine-h2-font-weight: var(--tnk-h2-font-weight);
+  --mantine-h3-font-weight: var(--tnk-h3-font-weight);
+  --mantine-h4-font-weight: var(--tnk-h4-font-weight);
+  --mantine-h5-font-weight: var(--tnk-h5-font-weight);
+  --mantine-h6-font-weight: var(--tnk-h6-font-weight);
 
   /* Line heights */
-  --mantine-line-height: var(--tnk-line-height-normal);
+  --mantine-line-height: var(--tnk-line-height-default);
   --mantine-line-height-xs: var(--tnk-line-height-tight);
   --mantine-line-height-sm: var(--tnk-line-height-normal);
   --mantine-line-height-md: var(--tnk-line-height-relaxed);
   --mantine-line-height-lg: var(--tnk-line-height-loose);
-  --mantine-h1-line-height: var(--tnk-line-height-normal);
-  --mantine-h2-line-height: var(--tnk-line-height-normal);
-  --mantine-h3-line-height: var(--tnk-line-height-normal);
-  --mantine-h4-line-height: var(--tnk-line-height-normal);
-  --mantine-h5-line-height: var(--tnk-line-height-normal);
-  --mantine-h6-line-height: var(--tnk-line-height-normal);
+  --mantine-h1-line-height: var(--tnk-h1-line-height);
+  --mantine-h2-line-height: var(--tnk-h2-line-height);
+  --mantine-h3-line-height: var(--tnk-h3-line-height);
+  --mantine-h4-line-height: var(--tnk-h4-line-height);
+  --mantine-h5-line-height: var(--tnk-h5-line-height);
+  --mantine-h6-line-height: var(--tnk-h6-line-height);
 
   /* Spacing */
   --mantine-spacing-xs: var(--tnk-space-xs);
@@ -186,7 +186,7 @@
   --mantine-spacing-xl: var(--tnk-space-xl);
 
   /* Border radius */
-  --mantine-radius-default: var(--tnk-radius-md);
+  --mantine-radius-default: var(--tnk-radius-default);
   --mantine-radius-xs: var(--tnk-radius-sm);
   --mantine-radius-sm: var(--tnk-radius-md);
   --mantine-radius-md: var(--tnk-radius-lg);
@@ -410,20 +410,20 @@
 /* Dark color scheme specific variables */
 @media (prefers-color-scheme: dark) {
   :root {
-    --mantine-color-bright: var(--mantine-color-white);
-    --mantine-color-text: var(--mantine-color-dark-0);
-    --mantine-color-body: var(--mantine-color-dark-7);
+    --mantine-color-bright: var(--tnk-white);
+    --mantine-color-text: var(--tnk-text-primary);
+    --mantine-color-body: var(--tnk-bg-primary);
     --mantine-color-error: var(--mantine-color-red-8);
-    --mantine-color-placeholder: var(--mantine-color-dark-3);
+    --mantine-color-placeholder: var(--tnk-text-tertiary);
     --mantine-color-anchor: var(--mantine-color-blue-4);
-    --mantine-color-default: var(--mantine-color-dark-6);
-    --mantine-color-default-hover: var(--mantine-color-dark-5);
-    --mantine-color-default-color: var(--mantine-color-white);
-    --mantine-color-default-border: var(--mantine-color-dark-4);
-    --mantine-color-dimmed: var(--mantine-color-dark-2);
-    --mantine-color-disabled: var(--mantine-color-dark-6);
-    --mantine-color-disabled-color: var(--mantine-color-dark-3);
-    --mantine-color-disabled-border: var(--mantine-color-dark-4);
+    --mantine-color-default: var(--tnk-bg-secondary);
+    --mantine-color-default-hover: var(--tnk-bg-tertiary);
+    --mantine-color-default-color: var(--tnk-text-primary);
+    --mantine-color-default-border: var(--tnk-border-primary);
+    --mantine-color-dimmed: var(--tnk-text-secondary);
+    --mantine-color-disabled: var(--tnk-bg-tertiary);
+    --mantine-color-disabled-color: var(--tnk-text-tertiary);
+    --mantine-color-disabled-border: var(--tnk-border-secondary);
 
     /* Dark theme color adjustments */
     --mantine-color-dark-text: var(--mantine-color-dark-4);

--- a/tanaka/extension/src/playground-react/styles/_tanaka_vars.scss
+++ b/tanaka/extension/src/playground-react/styles/_tanaka_vars.scss
@@ -23,25 +23,24 @@
   --tnk-error-light: rgba(239, 68, 68, 0.1);
   --tnk-error: #ef4444;
   --tnk-error-dark: #dc2626;
+  --tnk-info-light: rgba(6, 182, 212, 0.1);
+  --tnk-info: #06b6d4;
+  --tnk-info-dark: #0891b2;
 
   /* Colors - Text */
   --tnk-text-primary: #1f2937;
   --tnk-text-secondary: #6b7280;
   --tnk-text-tertiary: #9ca3af;
-  --tnk-text-muted: #9ca3af;
   --tnk-text-on-primary: #fff;
 
   /* Colors - Background */
   --tnk-bg-primary: #fff;
   --tnk-bg-secondary: #f5f5f7;
   --tnk-bg-tertiary: #f9fafb;
-  --tnk-bg-subtle: #f9fafb;
 
   /* Colors - Borders */
   --tnk-border-primary: #e5e7eb;
   --tnk-border-secondary: #f3f4f6;
-  --tnk-border: #e5e7eb;
-  --tnk-border-light: #f3f4f6;
 
   /* Colors - Gray Scale */
   --tnk-gray-50: #f8f9fa;
@@ -63,6 +62,13 @@
   --tnk-overlay-light: rgba(0, 0, 0, 0.05);
   --tnk-overlay-dark: rgba(255, 255, 255, 0.05);
 
+  /* Colors - Interactive States */
+  --tnk-focus-ring: var(--tnk-primary-light);
+  --tnk-focus-ring-width: 2px;
+  --tnk-focus-ring-offset: 2px;
+  --tnk-hover-opacity: 0.8;
+  --tnk-disabled-opacity: 0.6;
+
   /* Colors - Specific States */
   --tnk-error-bg-light: #fef2f2;
   --tnk-error-border-light: #fecaca;
@@ -74,8 +80,14 @@
   --tnk-shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 10%);
   --tnk-shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 25%);
 
+  /* Semantic Shadows */
+  --tnk-card-shadow: var(--tnk-shadow-md);
+  --tnk-dropdown-shadow: var(--tnk-shadow-lg);
+  --tnk-modal-shadow: var(--tnk-shadow-xl);
+
   /* Typography */
   --tnk-font-family: -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+  --tnk-font-family-headings: var(--tnk-font-family);
   --tnk-font-mono: "SF Mono", monaco, "Cascadia Code", monospace;
 
   /* Font Sizes */
@@ -94,25 +106,69 @@
   --tnk-text-body: var(--tnk-text-base);   /* 14px - body text */
   --tnk-text-header: var(--tnk-text-base); /* 14px - section headers */
 
+  /* Heading Sizes */
+  --tnk-h1-font-size: var(--tnk-text-4xl);
+  --tnk-h2-font-size: var(--tnk-text-3xl);
+  --tnk-h3-font-size: var(--tnk-text-2xl);
+  --tnk-h4-font-size: var(--tnk-text-xl);
+  --tnk-h5-font-size: var(--tnk-text-lg);
+  --tnk-h6-font-size: var(--tnk-text-base);
+
+  /* Heading Weights */
+  --tnk-h1-font-weight: var(--tnk-font-weight-bold);
+  --tnk-h2-font-weight: var(--tnk-font-weight-bold);
+  --tnk-h3-font-weight: var(--tnk-font-weight-bold);
+  --tnk-h4-font-weight: var(--tnk-font-weight-semibold);
+  --tnk-h5-font-weight: var(--tnk-font-weight-semibold);
+  --tnk-h6-font-weight: var(--tnk-font-weight-medium);
+
+  /* Heading Line Heights */
+  --tnk-h1-line-height: 1.3;
+  --tnk-h2-line-height: 1.35;
+  --tnk-h3-line-height: 1.4;
+  --tnk-h4-line-height: 1.45;
+  --tnk-h5-line-height: 1.5;
+  --tnk-h6-line-height: 1.5;
+
+  /* Component Font Sizes */
+  --tnk-body-font-size: var(--tnk-text-base);
+  --tnk-caption-font-size: var(--tnk-text-xs);
+  --tnk-button-font-size: var(--tnk-text-sm);
+  --tnk-input-font-size: var(--tnk-text-base);
+  --tnk-title-font-size: var(--tnk-text-2xl);
+
   /* Font Weights */
   --tnk-font-weight-normal: 400;
   --tnk-font-weight-medium: 500;
   --tnk-font-weight-semibold: 600;
   --tnk-font-weight-bold: 700;
 
+  /* Component Font Weights */
+  --tnk-heading-font-weight: var(--tnk-font-weight-bold);
+  --tnk-body-font-weight: var(--tnk-font-weight-normal);
+  --tnk-caption-font-weight: var(--tnk-font-weight-normal);
+  --tnk-button-font-weight: var(--tnk-font-weight-medium);
+  --tnk-input-font-weight: var(--tnk-font-weight-normal);
+
+  /* Component Line Heights */
+  --tnk-body-line-height: var(--tnk-line-height-normal);
+  --tnk-caption-line-height: var(--tnk-line-height-tight);
+  --tnk-button-line-height: var(--tnk-line-height-tight);
+  --tnk-input-line-height: var(--tnk-line-height-normal);
+
   /* Icon Sizes */
-  --tnk-icon-sz-default: 16px;
-  --tnk-icon-sz-xs: calc(var(--tnk-icon-sz-default) * 0.75); /* 12px */
-  --tnk-icon-sz-sm: calc(var(--tnk-icon-sz-default) * 0.875); /* 14px */
-  --tnk-icon-sz-md: calc(var(--tnk-icon-sz-default) * 1.125); /* 18px */
-  --tnk-icon-sz-lg: calc(var(--tnk-icon-sz-default) * 1.25); /* 20px */
-  --tnk-icon-sz-xl: calc(var(--tnk-icon-sz-default) * 1.5); /* 24px */
-  --tnk-icon-sz-2xl: calc(var(--tnk-icon-sz-default) * 2); /* 32px */
-  --tnk-icon-sz-3xl: calc(var(--tnk-icon-sz-default) * 3); /* 48px */
-  --tnk-icon-sz-4xl: calc(var(--tnk-icon-sz-default) * 4); /* 64px */
+  --tnk-icon-size-default: 16px;
+  --tnk-icon-size-xs: calc(var(--tnk-icon-size-default) * 0.75); /* 12px */
+  --tnk-icon-size-sm: calc(var(--tnk-icon-size-default) * 0.875); /* 14px */
+  --tnk-icon-size-md: calc(var(--tnk-icon-size-default) * 1.125); /* 18px */
+  --tnk-icon-size-lg: calc(var(--tnk-icon-size-default) * 1.25); /* 20px */
+  --tnk-icon-size-xl: calc(var(--tnk-icon-size-default) * 1.5); /* 24px */
+  --tnk-icon-size-2xl: calc(var(--tnk-icon-size-default) * 2); /* 32px */
+  --tnk-icon-size-3xl: calc(var(--tnk-icon-size-default) * 3); /* 48px */
+  --tnk-icon-size-4xl: calc(var(--tnk-icon-size-default) * 4); /* 64px */
 
   /* Logo Sizes */
-  --tnk-logo-size: 48px;
+  --tnk-logo-size-sm: 48px;
   --tnk-logo-size-md: 60px;
   --tnk-logo-size-lg: 72px;
 
@@ -143,17 +199,36 @@
   --tnk-radius-3xl: 16px;
   --tnk-radius-full: 9999px;
 
+  /* Semantic Radii */
+  --tnk-radius-default: var(--tnk-radius-md);
+  --tnk-button-radius: var(--tnk-radius-md);
+  --tnk-input-radius: var(--tnk-radius-md);
+  --tnk-card-radius: var(--tnk-radius-lg);
+  --tnk-modal-radius: var(--tnk-radius-xl);
+
   /* Border Widths */
   --tnk-border-width-hairline: 0.5px;
   --tnk-border-width: 1px;
   --tnk-border-width-thick: 2px;
   --tnk-border-width-accent: 3px;
+  --tnk-border-width-default: var(--tnk-border-width);
 
   /* Layout Dimensions */
   --tnk-container-max-width: 1400px;
   --tnk-button-min-width: 120px;
   --tnk-control-label-width: 100px;
   --tnk-search-icon-space: 40px;
+
+  /* Component Heights */
+  --tnk-input-height-sm: 32px;
+  --tnk-input-height-md: 36px;
+  --tnk-input-height-lg: 40px;
+  --tnk-button-height-sm: var(--tnk-input-height-sm);
+  --tnk-button-height-md: var(--tnk-input-height-md);
+  --tnk-button-height-lg: var(--tnk-input-height-lg);
+
+  /* Component Widths */
+  --tnk-card-min-width: 280px;
 
   /* Breakpoints */
   --tnk-breakpoint-sm: 640px;
@@ -165,6 +240,7 @@
   --tnk-transition-fast: 0.2s ease;
   --tnk-transition-base: 0.3s ease;
   --tnk-transition-slow: 0.5s ease;
+  --tnk-transition-default: var(--tnk-transition-base);
   --tnk-duration-normal: 0.2s;
 
   /* Line Heights */
@@ -172,6 +248,7 @@
   --tnk-line-height-normal: 1.4;
   --tnk-line-height-relaxed: 1.5;
   --tnk-line-height-loose: 1.6;
+  --tnk-line-height-default: var(--tnk-line-height-normal);
 
   /* Letter Spacing */
   --tnk-letter-spacing-tight: -0.025em;
@@ -207,6 +284,7 @@
   --tnk-scale-hover: 1.05;
   --tnk-scale-active: 0.95;
   --tnk-translate-hover: -1px;
+  --tnk-translate-hover-y: -4px;
 
   /* Z-index scale */
   --tnk-z-base: 1;
@@ -222,4 +300,29 @@
   --tnk-screen-lg: 62em;
   --tnk-screen-xl: 75em;
   --tnk-screen-2xl: 88em;
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Colors - Text */
+    --tnk-text-primary: #f9fafb;
+    --tnk-text-secondary: #d1d5db;
+    --tnk-text-tertiary: #9ca3af;
+    --tnk-text-on-primary: #fff;
+
+    /* Colors - Background */
+    --tnk-bg-primary: #111827;
+    --tnk-bg-secondary: #1f2937;
+    --tnk-bg-tertiary: #374151;
+
+    /* Colors - Borders */
+    --tnk-border-primary: #374151;
+    --tnk-border-secondary: #4b5563;
+
+    /* Colors - Interactive States */
+    --tnk-focus-ring: var(--tnk-primary);
+    --tnk-overlay-light: rgba(255, 255, 255, 0.1);
+    --tnk-overlay-dark: rgba(0, 0, 0, 0.2);
+  }
 }

--- a/tanaka/extension/src/playground-react/styles/globals.scss
+++ b/tanaka/extension/src/playground-react/styles/globals.scss
@@ -6,8 +6,8 @@
 @import 'mantine_vars';
 
 html, body {
-  margin: 0;
-  padding: 0;
+  margin: var(--tnk-space-none);
+  padding: var(--tnk-space-none);
   background-color: var(--tnk-bg-primary);
   color: var(--tnk-text-primary);
   font-family: var(--tnk-font-family);


### PR DESCRIPTION
- Add comprehensive semantic variables to _tanaka_vars.scss:
  - Heading sizes, weights, and line heights
  - Component-specific font sizes and weights
  - Interactive states (focus, hover, disabled)
  - Semantic shadows and radii
  - Dark mode support
- Update all SCSS files to use semantic variables:
  - Replace scale-based vars with semantic equivalents
  - Use --tnk-title-font-size for UI titles
  - Use --tnk-translate-hover-y for hover effects
  - Replace hardcoded values with design tokens
- Update Mantine variable mappings to use Tanaka semantic vars
- Fix Icon component default size from 'medium' to 'md'