### PR TITLE
feat: add Pandora directory for AI agents and slash commands

### DIFF
--- a/pandora/README.md
+++ b/pandora/README.md
@@ -1,0 +1,12 @@
+# Pandora
+
+AI agents and automation tools - artificial beings that serve and assist.
+
+## Structure
+
+- `slash-commands/` - Custom slash commands for AI code assistants
+
+## Etymology
+
+Named after Pandora from Greek mythology - the first artificial woman created by the gods, endowed with gifts from
+each deity. Like her mythological namesake, these agents bring powerful capabilities packaged in an elegant form.

--- a/pandora/slash-commands/README.md
+++ b/pandora/slash-commands/README.md
@@ -1,0 +1,56 @@
+# Pandora Slash Commands
+
+Custom slash commands for AI code assistants.
+
+## Structure
+
+```
+slash-commands/
+├── claude/           # Claude agent
+│   ├── claude/       # claude namespace
+│   │   ├── discuss.md
+│   │   └── think.md
+│   └── git/          # git namespace (future)
+│       └── commit.md
+├── codex/            # Codex agent (future)
+└── gemini/           # Gemini agent (future)
+```
+
+Pattern: `<agent>/<namespace>/<command>.md`
+
+## Installation
+
+### Claude Code
+Single symlink for all namespaces:
+
+```bash
+ln -sf ~/projects/nebulae/pandora/slash-commands/claude ~/.claude/commands
+```
+
+This makes all namespaces available:
+- `/claude:discuss` - from `claude/claude/discuss.md`
+- `/claude:think` - from `claude/claude/think.md`
+- `/git:commit` - from `claude/git/commit.md` (future)
+
+## Current Commands
+
+### claude namespace
+- `/claude:discuss` - Start a structured design discussion
+- `/claude:think` - Deep thinking and planning mode
+
+## Command Format
+
+Commands are markdown files with optional frontmatter. See
+[Claude Code Slash Commands Documentation](https://docs.anthropic.com/en/docs/claude-code/slash-commands) for full
+details.
+
+```markdown
+---
+allowed-tools: Tool1, Tool2
+argument-hint: <description>
+description: Brief command description
+model: claude-3-5-sonnet-20241022
+---
+
+Command instructions using $ARGUMENTS
+```

--- a/pandora/slash-commands/claude/claude/discuss.md
+++ b/pandora/slash-commands/claude/claude/discuss.md
@@ -1,0 +1,47 @@
+---
+description: Structured design discussion with decision logging
+argument-hint: <topic>
+---
+
+Start a structured design discussion about $ARGUMENTS.
+
+## Discussion Protocol
+
+When I receive this command, I will:
+
+1. **Confirm the topic** and ask if you want to create a decision log file named `<TOPIC>_LOG.md` (uppercase version of the topic)
+
+2. **Ask questions one at a time** with:
+   - Clear options (a, b, c, etc.)
+   - Context-appropriate detail level:
+     - Technical topics: capabilities, trade-offs, performance
+     - Creative topics: user experience, workflows
+     - Business topics: impact, effort, risks
+   - Wait for your confirmation before proceeding
+
+3. **Maintain a decision log** in ADR (Architecture Decision Record) format with:
+   - Hybrid overview at top (summary + key decisions + open questions + stats)
+   - Each decision documented with: Status, Context, Options Considered, Decision, Consequences
+   - Session markers when resuming discussions
+   - Sub-decisions for important clarifications
+   - Dual save approach: immediate raw logging + clean summary
+
+4. **Handle discussion flow**:
+   - Start broad, then narrow down with iterative refinement
+   - Adapt specificity based on your engagement level
+   - Allow deferring questions (revisit after 3-4 others)
+   - Context-sensitive scope management for related topics
+   - Natural session ending with optional summary prompt
+
+5. **Special behaviors**:
+   - If no topic given: Resume last discussion or show available discussions
+   - If already in discussion: Show current status and progress
+   - If you ask clarifying questions: Pause main flow, explore, then continue
+   - If earlier decisions need revision: Handle context-sensitively
+
+## State Management
+- Parse existing log file to understand current state
+- Add session markers when resuming
+- Track deferred questions with context notes
+
+Begin by confirming if you want to start/resume a discussion about "$ARGUMENTS".

--- a/pandora/slash-commands/claude/claude/think.md
+++ b/pandora/slash-commands/claude/claude/think.md
@@ -1,0 +1,11 @@
+---
+description: Think deeply and review project guidelines
+---
+
+Take a moment to think deeply and carefully re-read @CLAUDE.md. Pay special attention to:
+- The critical instructions section at the top
+- Git workflow requirements
+- Code style guidelines
+- Project-specific conventions
+
+Fully internalize these guidelines before proceeding.


### PR DESCRIPTION
## Summary
- Created Pandora directory as central location for AI-related tools and agents
- Set up slash-commands structure with agent/namespace/command pattern
- Migrated existing claude:discuss and claude:think commands

## Structure
```
pandora/
├── slash-commands/
│   └── claude/        # Claude agent
│       └── claude/    # claude namespace
│           ├── discuss.md
│           └── think.md
```

## Benefits
- Single symlink approach: `ln -sf ~/projects/nebulae/pandora/slash-commands/claude ~/.claude/commands`
- Easy to add new namespaces (git, test, build) without updating symlinks
- Clean separation between different AI agents (future: codex, gemini)

🤖 Generated with [Claude Code](https://claude.ai/code)